### PR TITLE
Provision GCS bucket: team-b-data

### DIFF
--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,0 +1,4 @@
+bucket_name      = "team-b-data"
+bucket_location  = "US"
+environment      = "dev"
+project_id       = "my-gcp-project"


### PR DESCRIPTION
This PR adds the Terraform variables for provisioning a GCS bucket named 'team-b-data'.